### PR TITLE
Fixed several API v4 issues

### DIFF
--- a/PluginCommandManager.cs
+++ b/PluginCommandManager.cs
@@ -19,6 +19,7 @@ namespace TinyCmds {
 
 		public PluginCommandManager() {
 			this.commandList = typeof(TinyCmds).GetMethods(BindingFlags.Public | BindingFlags.Instance)
+			this.commandList = typeof(PluginCommands).GetMethods(BindingFlags.Public | BindingFlags.Static)
 				.Where(method => method.GetCustomAttribute<CommandAttribute>() is not null)
 				.Select(m => new PluginCommand(m, TinyCmds.pluginHelpCommand, ChatUtil.ShowPrefixedError))
 				.ToList();

--- a/TinyCmds.csproj
+++ b/TinyCmds.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<Authors>VariableVixen</Authors>
 		<Company>-</Company>
-		<Version>3.0.0</Version>
+		<Version>3.0.1</Version>
 		<Description>This plugin adds tiny and simple but useful chat commands, and nothing more. It doesn't even have a UI.</Description>
 		<Copyright>Copyleft Vixen 2021</Copyright>
 		<PackageProjectUrl>https://github.com/PrincessRTFM/TinyCommands</PackageProjectUrl>
@@ -18,8 +18,10 @@
 		<NullableContextOptions>enable</NullableContextOptions>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>9.0</LangVersion>
+		<PreserveCompilationContext>false</PreserveCompilationContext>
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
 	</PropertyGroup>
 
@@ -40,7 +42,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="DalamudPackager" Version="2.1.4" />
-		<PackageReference Include="XivCommon" Version="3.0.2" />
+		<PackageReference Include="XivCommon" Version="3.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Fixed `System.NotSupportedException: Resolving to a collectible assembly is not supported.` exception when trying to load XivCommon from GAC by making sure the dependent assembly is copied to the output directory and packaged along with the plugin. This allows the plugin to properly load.
- Fixed command handler resolution by changing `BindingFlags.Instance` to `BindingFlags.Static` and the parent type to `PluginCommands` since all command handlers are static member methods of the `PluginCommands` class. This allows all commands to work again.